### PR TITLE
Use Ctrl+click to not close the original tab

### DIFF
--- a/contextPlus.js
+++ b/contextPlus.js
@@ -34,6 +34,7 @@ if (browser.contextualIdentities !== undefined) {
 
       browser.contextMenus.onClicked.addListener(function (info, tab) {
         if (contextStore.hasOwnProperty(info.menuItemId)) {
+          const moveTab = !info.modifiers.includes('Ctrl');
           const cookieStoreId = contextStore[info.menuItemId];
           const newTabData = {
             active,
@@ -43,14 +44,16 @@ if (browser.contextualIdentities !== undefined) {
             windowId
           } = tab;
 
-          browser.tabs.create({
+          const newTabPromise = browser.tabs.create({
             active,
             cookieStoreId,
-            index,
+            index: index + (moveTab ? 0 : 1),
             pinned,
             url,
             windowId
-          }).then(() => browser.tabs.remove(tab.id));
+          });
+          if(moveTab)
+            newTabPromise.then(() => browser.tabs.remove(tab.id));
         }
       });
     });

--- a/contextPlus.js
+++ b/contextPlus.js
@@ -52,8 +52,9 @@ if (browser.contextualIdentities !== undefined) {
             url,
             windowId
           });
-          if(moveTab)
+          if (moveTab) {
             newTabPromise.then(() => browser.tabs.remove(tab.id));
+          }
         }
       });
     });


### PR DESCRIPTION
This change does not close the original tab if you press Ctrl while clicking. Basically it's "copy to context" instead of "move to context".
It would also be great to have the same behavior using middle click, but I don't know if contextMenus allow listening to middle click.

I don't know if you accept PRs and if this is the right way to accomplish the task. If not, feel free to modify it.

