### PR TITLE
Account for missing modifiers key in 53.0

### DIFF
--- a/contextPlus.js
+++ b/contextPlus.js
@@ -38,7 +38,7 @@ const contextMenuContainers = {
 
     const onClickedHandler = async function (info, tab) {
       if (contextStore.hasOwnProperty(info.menuItemId)) {
-        const moveTab = !info.modifiers.includes("Ctrl");
+        const moveTab = !(info.modifiers && info.modifiers.includes("Ctrl"));
         const cookieStoreId = contextStore[info.menuItemId];
         const {
           active,

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Context Plus",
-  "version": "0.3.1",
+  "version": "0.3.2",
 
   "applications": {
     "gecko": {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Context Plus",
-  "version": "0.3.0",
+  "version": "0.3.1",
 
   "applications": {
     "gecko": {


### PR DESCRIPTION
**Account for missing modifiers key in 53.0**

Firefox 53.0 doesn't support modifier keys in onClick handlers in context menus.

Check whether the `modifiers` key exists on the info object passed to the handler before trying
to check whether the modifiers thing contains the `Ctrl` key.

**Bump version number :-/**

Also bump the version number twice because I'm bad at AMO