### PR TITLE
Add options UI and setting for context filtering

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+  trailingComma: "es5",
+};

--- a/contextPlus.js
+++ b/contextPlus.js
@@ -12,7 +12,7 @@ const contextMenuContainers = {
     orange: "ff9f00",
     red: "ff613d",
     pink: "ff4bda",
-    purple: "af51f5"
+    purple: "af51f5",
   },
   defaultCookieStoreId: "firefox-default",
   async onActivatedTabHandler({ tabId }) {
@@ -20,7 +20,7 @@ const contextMenuContainers = {
     const parentId = browser.contextMenus.create({
       id: "moveContext",
       title: "Move to Context",
-      contexts: ["tab", "page"]
+      contexts: ["tab", "page"],
     });
 
     const activeTab = await browser.tabs.get(tabId);
@@ -31,12 +31,12 @@ const contextMenuContainers = {
         type: "normal",
         title: "No Context",
         id: "contextPlus-default",
-        parentId
+        parentId,
       });
       browser.contextMenus.create({
         type: "separator",
         id: "contextPlus-separator",
-        parentId
+        parentId,
       });
     }
 
@@ -63,8 +63,8 @@ const contextMenuContainers = {
               id: `contextPlus-${context.name}`,
               parentId,
               icons: {
-                16: "data:image/svg+xml;utf8," + svg
-              }
+                16: "data:image/svg+xml;utf8," + svg,
+              },
             });
           });
       });
@@ -76,7 +76,7 @@ const contextMenuContainers = {
     contextStore = contextualIdentities.reduce(
       (store, context) => {
         return Object.assign({}, store, {
-          [`contextPlus-${context.name}`]: context.cookieStoreId
+          [`contextPlus-${context.name}`]: context.cookieStoreId,
         });
       },
       { "contextPlus-default": contextMenuContainers.defaultCookieStoreId }
@@ -106,7 +106,7 @@ const contextMenuContainers = {
           index: index + (moveTab ? 0 : 1),
           pinned,
           url,
-          windowId
+          windowId,
         });
         if (moveTab) {
           await newTabPromise;
@@ -119,7 +119,7 @@ const contextMenuContainers = {
       await contextMenuContainers.updateStore();
       contextMenuContainers.onActivatedTabHandler();
     });
-  }
+  },
 };
 
 contextMenuContainers.init();

--- a/manifest.json
+++ b/manifest.json
@@ -5,6 +5,7 @@
 
   "applications": {
     "gecko": {
+      "id": "context-plus@totallymike",
       "strict_min_version": "57.0"
     }
   },
@@ -20,10 +21,16 @@
     "scripts": ["contextPlus.js"]
   },
 
+  "options_ui": {
+    "page": "options.html",
+    "browser_style": true
+  },
+
   "permissions": [
     "contextMenus",
     "contextualIdentities",
     "cookies",
+    "storage",
     "tabs"
   ]
 }

--- a/options.html
+++ b/options.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+
+<html>
+  <head>
+    <meta charset="utf-8">
+  </head>
+
+<body>
+  <p>
+    Use the option below to set a regular expression that filters the list of containers that
+    are displayed in the context menu. This is useful for when you want to hide containers that you don't
+    want to actively manage (for instance, Temporary Containers that are prefixed with "tmp").
+  </p>
+  <p>Current filter: <b id="saved_regex"></b></p>
+  <form>
+      <label>Regex for hiding contexts: </label>
+      <input type="text" id="filter_regex" >
+      <button type="reset">Clear</button>
+      <p>
+        <button type="submit">Save</button>
+      </p>
+  </form>
+  <script src="options.js"></script>
+</body>
+
+</html>

--- a/options.js
+++ b/options.js
@@ -1,0 +1,19 @@
+function saveOptions(e) {
+  e.preventDefault();
+
+  const filterRegex = document.querySelector("#filter_regex").value.trim();
+  browser.storage.sync.set({ filterRegex });
+  document.querySelector("#saved_regex").innerText = filterRegex || "none set";
+}
+
+// Loads and displays the user's setting in the options UI
+async function restoreOptions() {
+  const filterStore = await browser.storage.sync.get("filterRegex");
+  const filterRegex = filterStore.filterRegex;
+
+  document.querySelector("#filter_regex").value = filterRegex || "";
+  document.querySelector("#saved_regex").innerText = filterRegex || "none set";
+}
+
+document.addEventListener("DOMContentLoaded", restoreOptions);
+document.querySelector("form").addEventListener("submit", saveOptions);


### PR DESCRIPTION
I wanted to have the ability to filter the list of containers that appear in the context menu (similar to how the [Switch Container Plus](https://github.com/stoically/switch-container-plus) addon does it). This commit adds a basic options UI with a setting to set a regex for filtering the list of containers. Since it saves this setting to storage, the additional `storage` permission is required.